### PR TITLE
Update Reader for pyglossary plugin API change

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -42,6 +42,5 @@ class Reader:
                 if self.entries_left > 0:
                     self.entries_left -= 1
                 names, article = conv.make_entry(*conv.parse_line(line))
-                entry = formats_common.Entry(names, article, defiFormat='h')
+                entry = self.glos.newEntry(names, article, defiFormat='h')
                 yield entry
-


### PR DESCRIPTION
In upstream commit [bb5ecaba][1], the API changed:

    add Glosasry.newEntry, use it in plugins instead of Entry class directly
    this fixes bug of not considering default defiFormat

[1]: https://github.com/ilius/pyglossary/commit/bb5ecaba